### PR TITLE
Add extract alfanumeric with selected special characters

### DIFF
--- a/str/string.go
+++ b/str/string.go
@@ -30,7 +30,7 @@ func ExtractAlfaNumericFromText(source string) string {
 }
 
 func ExtractAlfaNumericWithSelectedSpecialCharactersFromText(source string) string {
-	// allowed special characters are !"#$%&'()*+,-./ \[]
+	// allowed special characters are !"#$%&'()*+,-./ \[]\n
 	var result strings.Builder
 	for i := 0; i < len(source); i++ {
 		b := source[i]

--- a/str/string.go
+++ b/str/string.go
@@ -29,6 +29,21 @@ func ExtractAlfaNumericFromText(source string) string {
 	return result.String()
 }
 
+func ExtractAlfaNumericWithSelectedSpecialCharactersFromText(source string) string {
+	// allowed special characters are !"#$%&'()*+,-./ \[]
+	var result strings.Builder
+	for i := 0; i < len(source); i++ {
+		b := source[i]
+		if (32 <= b && b <= 57) ||
+			(65 <= b && b <= 93) ||
+			(97 <= b && b <= 122) ||
+			b == 10 {
+			result.WriteByte(b)
+		}
+	}
+	return result.String()
+}
+
 func SplitOnNotEmpty(str string, delimiter string) []string {
 	if strings.TrimSpace(str) != "" {
 		var result []string

--- a/str/string_test.go
+++ b/str/string_test.go
@@ -1,0 +1,13 @@
+package str
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestExtractAlfaNumericWithSelectedSpecialCharactersFromText(t *testing.T) {
+	sourceText := "Ab9 \\!@#$%^&*_+-=\n"
+	validateText := "Ab9 \\!#$%&*+-\n"
+	filteredText := ExtractAlfaNumericWithSelectedSpecialCharactersFromText(sourceText)
+	assert.Equal(t, validateText, filteredText)
+}


### PR DESCRIPTION
add commonly used special characters to be included with alfa numeric extraction from a string.
allowed special characters are `!"#$%&'()*+,-./ \[]\n`